### PR TITLE
Add note about GPG signed commits to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Gmail Migrator
 
-[![CI](https://github.com/yourusername/gmail-migrator/actions/workflows/ci.yml/badge.svg)](https://github.com/yourusername/gmail-migrator/actions/workflows/ci.yml)
-[![Pre-commit](https://github.com/yourusername/gmail-migrator/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/yourusername/gmail-migrator/actions/workflows/pre-commit.yml)
-[![Docker Compose Test](https://github.com/yourusername/gmail-migrator/actions/workflows/docker-compose-test.yml/badge.svg)](https://github.com/yourusername/gmail-migrator/actions/workflows/docker-compose-test.yml)
-[![Signed Commits](https://github.com/yourusername/gmail-migrator/actions/workflows/verify-commit-signature.yml/badge.svg)](https://github.com/yourusername/gmail-migrator/actions/workflows/verify-commit-signature.yml)
+[![CI](https://github.com/TheHenrick/gmail-migrator/actions/workflows/ci.yml/badge.svg)](https://github.com/TheHenrick/gmail-migrator/actions/workflows/ci.yml)
+[![Pre-commit](https://github.com/TheHenrick/gmail-migrator/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/TheHenrick/gmail-migrator/actions/workflows/pre-commit.yml)
+[![Docker Compose Test](https://github.com/TheHenrick/gmail-migrator/actions/workflows/docker-compose-test.yml/badge.svg)](https://github.com/TheHenrick/gmail-migrator/actions/workflows/docker-compose-test.yml)
+[![Signed Commits](https://github.com/TheHenrick/gmail-migrator/actions/workflows/verify-commit-signature.yml/badge.svg)](https://github.com/TheHenrick/gmail-migrator/actions/workflows/verify-commit-signature.yml)
 
 A tool to help users migrate their Gmail emails to other email service providers like Outlook, Yahoo Mail, and others.
+
+> **Note:** This repository requires GPG signed commits for all contributions.
 
 ## Features (Planned)
 


### PR DESCRIPTION
This PR adds a simple note to the README about the requirement for GPG signed commits. This is a test PR to verify GPG signature verification is working correctly.